### PR TITLE
Fixed some issues encountered when editing the news_top block

### DIFF
--- a/blocks/news_top.php
+++ b/blocks/news_top.php
@@ -402,7 +402,7 @@ function b_news_top_show($options)
             $stories = NewsStory::getAllPublished($options[1], 0, $restricted, $topics, 1, true, $options[0]);
         }
 
-        if (!count($stories)) {
+        if (!$stories) {
             return '';
         }
         $topic = new  NewsTopic();

--- a/blocks/news_top.php
+++ b/blocks/news_top.php
@@ -22,6 +22,7 @@ use XoopsModules\News;
 use XoopsModules\News\Helper;
 use XoopsModules\News\NewsStory;
 use XoopsModules\News\NewsTopic;
+use XoopsModules\News\XoopsTree;
 
 //require_once XOOPS_ROOT_PATH . '/modules/news/class/class.newsstory.php';
 //require_once XOOPS_ROOT_PATH . '/modules/news/class/class.newstopic.php';
@@ -672,7 +673,7 @@ function b_news_top_edit($options)
     //    require_once XOOPS_ROOT_PATH . '/modules/news/class/class.newstopic.php';
     $topics_arr = [];
     //    require_once XOOPS_ROOT_PATH . '/modules/news/class/xoopstree.php';
-    $xt         = new \XoopsTree($xoopsDB->prefix('news_topics'), 'topic_id', 'topic_pid');
+    $xt         = new XoopsTree($xoopsDB->prefix('news_topics'), 'topic_id', 'topic_pid');
     $topics_arr = $xt->getChildTreeArray(0, 'topic_title');
     $size       = count($options);
     foreach ($topics_arr as $onetopic) {

--- a/class/NewsStory.php
+++ b/class/NewsStory.php
@@ -217,7 +217,7 @@ class NewsStory extends XoopsStory
      * @param bool   $asobject
      * @param string $order
      * @param bool   $topic_frontpage
-     * @return array
+     * @return array|null
      */
     public static function getAllPublished(
         $limit = 0,


### PR DESCRIPTION
Please refer to the commit messages for more details.
I don't really understand the original intention for loading XoopsTree in news_top, but this seems to work.