### PR TITLE
 Moved override of $approve for news module admin users out of story forms

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1846,7 +1846,7 @@ switch ($op) {
         $helper = Helper::getInstance();
         $helper->loadLanguage('main');
 
-        if (1 == $helper->getConfig('autoapprove')) {
+        if (1 == $helper->getConfig('autoapprove') || (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
             $approve = 1;
         }
         $approveprivilege = 1;

--- a/blocks/news_moderate.php
+++ b/blocks/news_moderate.php
@@ -67,8 +67,8 @@ function b_news_topics_moderate()
             $story['action']      = "<a href='" . XOOPS_URL . '/modules/news/admin/index.php?op=edit&amp;storyid=' . $newstory->storyid() . "'>" . _EDIT . "</a> - <a href='" . XOOPS_URL . '/modules/news/admin/index.php?op=delete&amp;storyid=' . $newstory->storyid() . "'>" . _MB_DELETE . '</a>';
             $story['topic_title'] = $newstory->topic_title();
             $story['topic_color'] = '#' . $myts->displayTarea($newstory->topic_color);
-            $block['picture']     = XOOPS_URL . '/uploads/news/image/' . $story->picture();
-            $block['pictureinfo'] = $story->pictureinfo();
+            $block['picture']     = XOOPS_URL . '/uploads/news/image/' . $newstory->picture();
+            $block['pictureinfo'] = $newstory->pictureinfo();
             $block['stories'][]   = &$story;
             unset($story);
         }

--- a/blocks/news_moderate.php
+++ b/blocks/news_moderate.php
@@ -22,7 +22,7 @@ use XoopsModules\News\Helper;
 use XoopsModules\News\NewsStory;
 
 /**
- * Dispay a block where news moderators can show news that need to be moderated.
+ * Display a block where news moderators can show news that needs to be moderated.
  */
 function b_news_topics_moderate()
 {

--- a/include/storyform.inc.php
+++ b/include/storyform.inc.php
@@ -170,9 +170,6 @@ if ($allowupload) {
 $option_tray = new \XoopsFormElementTray(_OPTIONS, '<br>');
 //Set date of publish/expiration
 if ($approveprivilege) {
-    if (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid'))) {
-        $approve = 1;
-    }
     $approve_checkbox = new \XoopsFormCheckBox('', 'approve', $approve);
     $approve_checkbox->addOption(1, _AM_APPROVE);
     $option_tray->addElement($approve_checkbox);

--- a/include/storyform.original.php
+++ b/include/storyform.original.php
@@ -168,9 +168,6 @@ if ($allowupload) {
 $option_tray = new \XoopsFormElementTray(_OPTIONS, '<br>');
 //Set date of publish/expiration
 if ($approveprivilege) {
-    if (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid'))) {
-        $approve = 1;
-    }
     $approve_checkbox = new \XoopsFormCheckBox('', 'approve', $approve);
     $approve_checkbox->addOption(1, _AM_APPROVE);
     $option_tray->addElement($approve_checkbox);

--- a/submit.php
+++ b/submit.php
@@ -252,9 +252,6 @@ switch ($op) {
         if ($approveprivilege) {
             $nohtml = Request::getInt('nohtml', 0, 'POST');
             $story->setNohtml($nohtml);
-            if (!isset($_POST['approve'])) {
-                $approve = 0;
-            }
         } else {
             $story->setNohtml = 1;
         }

--- a/submit.php
+++ b/submit.php
@@ -157,7 +157,7 @@ switch ($op) {
         $pictureinfo = $story->pictureinfo;
         $approve     = 0;
         $published   = $story->published();
-        if (isset($published) && $published > 0) {
+        if ((isset($published) && $published > 0) || (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
             $approve = 1;
         }
         if (0 != $story->published()) {
@@ -573,7 +573,7 @@ switch ($op) {
             $expired      = 0;
             $published    = 0;
         }
-        if (1 == $helper->getConfig('autoapprove')) {
+        if (1 == $helper->getConfig('autoapprove') || (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
             $approve = 1;
         }
         require_once XOOPS_ROOT_PATH . '/modules/news/include/storyform.inc.php';

--- a/submit.php
+++ b/submit.php
@@ -370,7 +370,7 @@ switch ($op) {
             if (!$approve) {
                 $story->setPublished(0);
             }
-        } elseif (1 == $helper->getConfig('autoapprove') && !$approveprivilege) {
+        } elseif (1 == $helper->getConfig('autoapprove')) {
             if (empty($storyid)) {
                 $approve = 1;
             } else {

--- a/xoops_version.php
+++ b/xoops_version.php
@@ -341,7 +341,7 @@ $modversion['config'][] = [
  */
 
 /**
- * Auto approuve submited stories
+ * Auto approve submited stories
  */
 $modversion['config'][] = [
     'name'        => 'autoapprove',
@@ -353,7 +353,7 @@ $modversion['config'][] = [
 ];
 
 /**
- * Dispay layout, classic or by topics
+ * Display layout, classic or by topics
  */
 $modversion['config'][] = [
     'name'        => 'newsdisplay',
@@ -366,7 +366,7 @@ $modversion['config'][] = [
 ];
 
 /**
- * How to display Author's name, username, full name or nothing ?
+ * How to display author's name - username, full name or nothing?
  */
 $modversion['config'][] = [
     'name'        => 'displayname',
@@ -381,6 +381,7 @@ $modversion['config'][] = [
         '_MI_DISPLAYNAME3' => 3,
     ],
 ];
+
 /**
  * Number of columns to use to display news
  */
@@ -393,6 +394,7 @@ $modversion['config'][] = [
     'default'     => 1,
     'options'     => [1 => 1, 2 => 2, 3 => 3, 4 => 4, 5 => 5],
 ];
+
 /**
  * Number of news and topics to display in the module's admin part
  */


### PR DESCRIPTION
and fixed the moderate news block, amongst other smaller clean-up.
Please see the individual commit messages for more details.