### PR TITLE
Clarified notify publish form label.

### DIFF
--- a/language/english/main.php
+++ b/language/english/main.php
@@ -14,7 +14,7 @@ define('_NW_SUBMITNEWS', 'Submit news');
 define('_NW_TITLE', 'Title');
 define('_NW_TOPIC', 'Topic');
 define('_NW_THESCOOP', 'The Scoop');
-define('_NW_NOTIFYPUBLISH', 'Notify by mail when published');
+define('_NW_NOTIFYPUBLISH', 'Notify me when this story is published');
 define('_NW_POST', 'Post');
 define('_NW_GO', 'Go!');
 define('_NW_THANKS', 'Thanks for your submission.'); //submission of news article


### PR DESCRIPTION
Based on submit.php (lines 487 to 491), this only subscribes the current user to a notification that the story is published (a.k.a., "approved"). Presumably this would be in whatever form the user has set for notifications, rather than always being an email.