### PR TITLE
Made checking "Approve" by default for module admin users configurable.

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -1832,7 +1832,9 @@ switch ($op) {
         $helper       = Helper::getInstance();
         $helper->loadLanguage('main');
 
-        if (1 == $helper->getConfig('autoapprove') || (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
+        if (1 == $helper->getConfig('autoapprove')) {
+            $approve = 1;
+        } elseif (1 == $helper->getConfig('moduleAdminApproveChecked') && (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
             $approve = 1;
         }
         $approveprivilege = 1;

--- a/language/english/modinfo.php
+++ b/language/english/modinfo.php
@@ -30,6 +30,7 @@ define('_MI_DISPLAYNAV', 'Select yes to display navigation box at the top of eac
 define('_MI_AUTOAPPROVE', 'Auto approve news stories without admin intervention?');
 define('_MI_ALLOWEDSUBMITGROUPS', 'Groups who can submit news');
 define('_MI_ALLOWEDAPPROVEGROUPS', 'Groups who can approve news');
+define('_MI_DEFAULT_APPROVE_CHECKED_FOR_ADMINS', 'Should the Approve checkbox be ticked by default for module admins?');
 define('_MI_NEWSDISPLAY', 'News display layout');
 define('_MI_NAMEDISPLAY', "Author's name");
 define('_MI_COLUMNMODE', 'Columns');
@@ -43,6 +44,7 @@ define('_MI_DISPLAYNAVDSC', '');
 define('_MI_AUTOAPPROVEDSC', '');
 define('_MI_ALLOWEDSUBMITGROUPSDESC', 'The selected groups will be able to submit news items');
 define('_MI_ALLOWEDAPPROVEGROUPSDESC', 'The selected groups will be able to approve news items');
+define('_MI_DEFAULT_APPROVE_CHECKED_FOR_ADMINS_DESC', 'The checkbox is shown to users who can approve news. This sets whether it is checked by default for users who also have news module admin rights.');
 define('_MI_NEWSDISPLAYDESC', 'Classic shows all news ordered by date of publish. News by topic will group the news by topic with the latest story in full and the others with just the title');
 define('_MI_ADISPLAYNAMEDSC', "Select how to display the author's name");
 define('_MI_COLUMNMODE_DESC', 'You can choose the number of columns to display articles list');

--- a/submit.php
+++ b/submit.php
@@ -155,7 +155,9 @@ switch ($op) {
         $pictureinfo = $story->pictureinfo;
         $approve     = 0;
         $published   = $story->published();
-        if ((isset($published) && $published > 0) || (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
+        if (isset($published) && $published > 0) {
+            $approve = 1;
+        } elseif (1 == $helper->getConfig('moduleAdminApproveChecked') && (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
             $approve = 1;
         }
         if (0 != $story->published()) {
@@ -573,7 +575,9 @@ switch ($op) {
             $expired      = 0;
             $published    = 0;
         }
-        if (1 == $helper->getConfig('autoapprove') || (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
+        if (1 == $helper->getConfig('autoapprove')) {
+            $approve = 1;
+        } elseif (1 == $helper->getConfig('moduleAdminApproveChecked') && (is_object($xoopsUser) && $xoopsUser->isAdmin($xoopsModule->getVar('mid')))) {
             $approve = 1;
         }
         require_once XOOPS_ROOT_PATH . '/modules/news/include/storyform.inc.php';

--- a/xoops_version.php
+++ b/xoops_version.php
@@ -352,6 +352,18 @@ $modversion['config'][] = [
 ];
 
 /**
+ * Whether to check the Approve checkbox by default for module admin users
+ */
+$modversion['config'][] = [
+    'name'        => 'moduleAdminApproveChecked',
+    'title'       => '_MI_DEFAULT_APPROVE_CHECKED_FOR_ADMINS',
+    'description' => '_MI_DEFAULT_APPROVE_CHECKED_FOR_ADMINS_DESC',
+    'formtype'    => 'yesno',
+    'valuetype'   => 'int',
+    'default'     => 1,
+];
+
+/**
  * Display layout, classic or by topics
  */
 $modversion['config'][] = [


### PR DESCRIPTION
Via a new option in the module's preferences. The intention is to allow users who happen to be module administrators (because, e.g., they're webmasters) to still treat approval as a two-stage process by default - like users who are not module admins.